### PR TITLE
Fixes issue with error message for arb-tree/bin-tree missing genrec

### DIFF
--- a/tags.rkt
+++ b/tags.rkt
@@ -149,7 +149,7 @@
                    (when (and (member type '(bin-tree arb-tree))
                               (not (member 'genrec ts)))
                      (raise-syntax-error '@template
-                                         (format "using ~a requires also using genrec" stx stx)))]
+                                         (format "using ~a requires also using genrec" type)))]
                   [else
                    (raise-syntax-error '@template (format "~a should be a TypeName or one of ~s." type TEMPLATE-ORIGINS) stx stx)])))
      (stepper-void)]))

--- a/tags.rkt
+++ b/tags.rkt
@@ -149,7 +149,7 @@
                    (when (and (member type '(bin-tree arb-tree))
                               (not (member 'genrec ts)))
                      (raise-syntax-error '@template
-                                         (format "using ~a requires also using genrec" type)))]
+                                         (format "using ~a requires also using genrec" type) stx stx))]
                   [else
                    (raise-syntax-error '@template (format "~a should be a TypeName or one of ~s." type TEMPLATE-ORIGINS) stx stx)])))
      (stepper-void)]))


### PR DESCRIPTION
There's a bug on the error formatting when a student misses gen-rec on the template:
```
(require spd/tags)
(@template arb-tree)
```

Currently, message is:
``<racket-path>/collects/spd/tags.rkt:152:41: format: format string requires 1 arguments, given 2; arguments were: "using ~a requires also using genrec" #<syntax:4:11 arb-tree> #<syntax:4:11 arb-tree>``

With this fix, message becomes:

``@template: using arb-tree requires also using genrec``